### PR TITLE
Refactor payments to use decimal

### DIFF
--- a/app/controllers/financing/financings_controller.rb
+++ b/app/controllers/financing/financings_controller.rb
@@ -58,7 +58,7 @@ module Financing
 
     def financing_params
       params.require(:financing)
-            .permit(:name, :borrowed_value_cents, :installments)
+            .permit(:name, :borrowed_value, :installments)
             .merge(user_id: current_user.id)
     end
   end

--- a/app/decorators/financings/financing_decorator.rb
+++ b/app/decorators/financings/financing_decorator.rb
@@ -16,17 +16,17 @@ module Financings
 
     def outstanding_balance
       value = object.payments.order(payment_date: :asc).reduce(object.borrowed_value) do |result, parcel|
-        (result - parcel.amortization_cents) + parcel.monetary_correction_cents
+        (result - parcel.amortization) + parcel.monetary_correction
       end
       format_currency(value)
     end
 
     def total_amortization
-      format_currency(object.payments.sum(:amortization_cents))
+      format_currency(object.payments.sum(:amortization))
     end
 
     def total_interest_paid
-      format_currency(object.payments.sum(:interest_cents))
+      format_currency(object.payments.sum(:interest))
     end
 
     def ordinary_parcels
@@ -38,7 +38,7 @@ module Financings
     end
 
     def monetary_correction
-      format_currency(object.payments.sum(:monetary_correction_cents))
+      format_currency(object.payments.sum(:monetary_correction))
     end
 
     def format_currency(value)

--- a/app/decorators/financings/financing_decorator.rb
+++ b/app/decorators/financings/financing_decorator.rb
@@ -3,7 +3,7 @@ module Financings
     decorates_association :payments, with: Financings::PaymentDecorator
 
     def borrowed_value
-      "R$ #{object.borrowed_value_cents / 100.0}"
+      format_currency(object.borrowed_value)
     end
 
     def name
@@ -15,18 +15,18 @@ module Financings
     end
 
     def outstanding_balance
-      value = object.payments.order(payment_date: :asc).reduce(object.borrowed_value_cents) do |result, parcel|
+      value = object.payments.order(payment_date: :asc).reduce(object.borrowed_value) do |result, parcel|
         (result - parcel.amortization_cents) + parcel.monetary_correction_cents
       end
-      value / 100.0
+      format_currency(value)
     end
 
     def total_amortization
-      object.payments.sum(:amortization_cents) / 100.0
+      format_currency(object.payments.sum(:amortization_cents))
     end
 
     def total_interest_paid
-      object.payments.sum(:interest_cents) / 100.0
+      format_currency(object.payments.sum(:interest_cents))
     end
 
     def ordinary_parcels
@@ -38,7 +38,11 @@ module Financings
     end
 
     def monetary_correction
-      object.payments.sum(:monetary_correction_cents) / 100.0
+      format_currency(object.payments.sum(:monetary_correction_cents))
+    end
+
+    def format_currency(value)
+      ActionController::Base.helpers.number_to_currency(value, unit: 'R$ ', separator: ',', delimiter: '.')
     end
 
     delegate :id, :installments, to: :object

--- a/app/decorators/financings/payment_decorator.rb
+++ b/app/decorators/financings/payment_decorator.rb
@@ -5,35 +5,35 @@ module Financings
     end
 
     def parcel_value
-      value = (object.amortization_cents +
-       object.interest_cents +
-       object.insurance_cents +
-       + object.fees_cents + object.adjustment_cents) / 100.0
+      value = (object.amortization +
+       object.interest +
+       object.insurance +
+       + object.fees + object.adjustment) / 100.0
       format_currency(value)
     end
 
     def interest
-      format_currency(object.interest_cents / 100.0)
+      format_currency(object.interest / 100.0)
     end
 
     def amortization
-      format_currency(object.amortization_cents / 100.0)
+      format_currency(object.amortization / 100.0)
     end
 
     def insurance
-      format_currency(object.insurance_cents / 100.0)
+      format_currency(object.insurance / 100.0)
     end
 
     def fees
-      format_currency(object.fees_cents / 100.0)
+      format_currency(object.fees / 100.0)
     end
 
     def adjustment
-      format_currency(object.adjustment_cents / 100.0)
+      format_currency(object.adjustment / 100.0)
     end
 
     def monetary_correction
-      format_currency(object.monetary_correction_cents / 100.0)
+      format_currency(object.monetary_correction / 100.0)
     end
 
     def format_currency(value)

--- a/app/services/financing_services/create_financing.rb
+++ b/app/services/financing_services/create_financing.rb
@@ -2,7 +2,7 @@ module FinancingServices
   class CreateFinancing
     def initialize(params)
       @user_id = params[:user_id]
-      @borrowed_value = params[:borrowed_value_cents]
+      @borrowed_value = params[:borrowed_value]
       @installments = params[:installments]
       @name = params[:name]
     end
@@ -25,13 +25,13 @@ module FinancingServices
       {
         name: name,
         user_id: user_id,
-        borrowed_value_cents: value_to_cents(borrowed_value),
+        borrowed_value: value_to_decimal(borrowed_value),
         installments: installments
       }
     end
 
-    def value_to_cents(value)
-      value.to_f * 100
+    def value_to_decimal(value)
+      value.to_d
     end
   end
 end

--- a/app/services/financing_services/create_payment.rb
+++ b/app/services/financing_services/create_payment.rb
@@ -27,19 +27,19 @@ module FinancingServices
         paid_parcels: params[:paid_parcels],
         ordinary: params[:ordinary],
         payment_date: set_date,
-        amortization_cents: value_to_cents(params[:amortization]),
-        fees_cents: value_to_cents(params[:fees]),
-        interest_cents: value_to_cents(params[:interest]),
-        insurance_cents: value_to_cents(params[:insurance]),
-        adjustment_cents: value_to_cents(params[:adjustment]),
-        monetary_correction_cents: value_to_cents(params[:monetary_correction])
+        amortization: value_to_decimal(params[:amortization]),
+        fees: value_to_decimal(params[:fees]),
+        interest: value_to_decimal(params[:interest]),
+        insurance: value_to_decimal(params[:insurance]),
+        adjustment: value_to_decimal(params[:adjustment]),
+        monetary_correction: value_to_decimal(params[:monetary_correction])
       }
     end
 
-    def value_to_cents(value)
+    def value_to_decimal(value)
       return 0 if value.nil?
 
-      value.gsub(',', '.').to_f * 100
+      value.to_d
     end
 
     def financing

--- a/app/services/financing_services/update_financing.rb
+++ b/app/services/financing_services/update_financing.rb
@@ -2,7 +2,7 @@ module FinancingServices
   class UpdateFinancing
     def initialize(financing_id, params)
       @user_id = params[:user_id]
-      @borrowed_value = params[:borrowed_value_cents]
+      @borrowed_value = params[:borrowed_value]
       @installments = params[:installments]
       @name = params[:name]
       @financing_id = financing_id
@@ -32,7 +32,7 @@ module FinancingServices
     def financing_attributes
       {
         name: new_name,
-        borrowed_value_cents: new_borrowed_value,
+        borrowed_value: new_borrowed_value,
         installments: new_installments
       }
     end
@@ -42,15 +42,15 @@ module FinancingServices
     end
 
     def new_borrowed_value
-      borrowed_value.nil? ? financing.borrowed_value_cents : value_to_cents(borrowed_value)
+      borrowed_value.nil? ? financing.borrowed_value : value_to_decimal(borrowed_value)
     end
 
     def new_installments
       installments.nil? ? financing.installments : installments
     end
 
-    def value_to_cents(value)
-      value.to_f * 100
+    def value_to_decimal(value)
+      value.to_d
     end
   end
 end

--- a/app/services/financing_services/update_payment.rb
+++ b/app/services/financing_services/update_payment.rb
@@ -32,19 +32,19 @@ module FinancingServices
         paid_parcels: params[:paid_parcels],
         ordinary: params[:ordinary],
         payment_date: params[:payment_date],
-        amortization_cents: value_to_cents(params[:amortization]),
-        interest_cents: value_to_cents(params[:interest]),
-        fees_cents: value_to_cents(params[:fees]),
-        insurance_cents: value_to_cents(params[:insurance]),
-        adjustment_cents: value_to_cents(params[:adjustment]),
-        monetary_correction_cents: value_to_cents(params[:monetary_correction])
+        amortization: value_to_decimal(params[:amortization]),
+        interest: value_to_decimal(params[:interest]),
+        fees: value_to_decimal(params[:fees]),
+        insurance: value_to_decimal(params[:insurance]),
+        adjustment: value_to_decimal(params[:adjustment]),
+        monetary_correction: value_to_decimal(params[:monetary_correction])
       }
     end
 
-    def value_to_cents(value)
+    def value_to_decimal(value)
       return 0 if value.nil?
 
-      value.gsub(',', '.').to_f * 100
+      value.to_d
     end
   end
 end

--- a/app/views/financing/financings/_form.html.erb
+++ b/app/views/financing/financings/_form.html.erb
@@ -6,8 +6,8 @@
   <%= form_error_notification(financing) %>
 
   <%= f.input :name, label: t('financing.form.name'),input_html: { autofocus: true } %>
-  <%= f.input :borrowed_value_cents, label: t('financing.form.borrowed_amount'),
-   input_html: { value: (financing.borrowed_value_cents / 100.0 if financing.borrowed_value_cents)
+  <%= f.input :borrowed_value, label: t('financing.form.borrowed_amount'),
+   input_html: { value: (financing.borrowed_value if financing.borrowed_value)
     } %>
   <%= f.input :installments, label: t('financing.form.parcels') %>
   <%= f.submit t('buttons.save'), class: "btn btn--secondary" %>

--- a/db/migrate/20240807200854_change_borrowed_value_cents_to_decimal_in_financings.rb
+++ b/db/migrate/20240807200854_change_borrowed_value_cents_to_decimal_in_financings.rb
@@ -1,0 +1,10 @@
+class ChangeBorrowedValueCentsToDecimalInFinancings < ActiveRecord::Migration[7.0]
+
+  def up
+    change_column :financings, :borrowed_value_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :financings, :borrowed_value_cents, :integer
+  end
+end

--- a/db/migrate/20240807202032_rename_borrowed_value_cents_in_financings.rb
+++ b/db/migrate/20240807202032_rename_borrowed_value_cents_in_financings.rb
@@ -1,0 +1,9 @@
+class RenameBorrowedValueCentsInFinancings < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :financings, :borrowed_value_cents, :borrowed_value
+  end
+
+  def down
+    rename_column :financings, :borrowed_value, :borrowed_value_cents
+  end
+end

--- a/db/migrate/20240808002131_change_integer_to_decimal_in_payments.rb
+++ b/db/migrate/20240808002131_change_integer_to_decimal_in_payments.rb
@@ -1,0 +1,19 @@
+class ChangeIntegerToDecimalInPayments < ActiveRecord::Migration[7.0]
+  def up
+    change_column :payments, :amortization_cents, :decimal, precision: 15, scale: 2
+    change_column :payments, :interest_cents, :decimal, precision: 15, scale: 2
+    change_column :payments, :insurance_cents, :decimal, precision: 15, scale: 2
+    change_column :payments, :fees_cents, :decimal, precision: 15, scale: 2
+    change_column :payments, :monetary_correction_cents, :decimal, precision: 15, scale: 2
+    change_column :payments, :adjustment_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :payments, :amortization_cents, :integer
+    change_column :payments, :interest_cents, :integer
+    change_column :payments, :insurance_cents, :integer
+    change_column :payments, :fees_cents, :integer
+    change_column :payments, :monetary_correction_cents, :integer
+    change_column :payments, :adjustment_cents, :integer
+  end
+end

--- a/db/migrate/20240808002529_rename_columns_in_payments.rb
+++ b/db/migrate/20240808002529_rename_columns_in_payments.rb
@@ -1,0 +1,20 @@
+class RenameColumnsInPayments < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :payments, :amortization_cents, :amortization
+    rename_column :payments, :interest_cents, :interest
+    rename_column :payments, :insurance_cents, :insurance
+    rename_column :payments, :fees_cents, :fees
+    rename_column :payments, :monetary_correction_cents, :monetary_correction
+    rename_column :payments, :adjustment_cents, :adjustment
+  end
+
+  def down
+    rename_column :payments, :amortization, :amortization_cents
+    rename_column :payments, :interest, :interest_cents
+    rename_column :payments, :insurance, :insurance_cents
+    rename_column :payments, :fees, :fees_cents
+    rename_column :payments, :monetary_correction, :monetary_correction_cents
+    rename_column :payments, :adjustment, :adjustment_cents
+    end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_30_021809) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_07_202032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_021809) do
 
   create_table "financings", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "borrowed_value_cents", default: 0, null: false
+    t.decimal "borrowed_value", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "installments", default: 0, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_07_202032) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_08_002529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,12 +100,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_07_202032) do
     t.integer "parcel", default: 0
     t.integer "paid_parcels", default: 1
     t.date "payment_date"
-    t.integer "amortization_cents", default: 0
-    t.integer "interest_cents", default: 0
-    t.integer "insurance_cents", default: 0
-    t.integer "fees_cents", default: 0
-    t.integer "monetary_correction_cents", default: 0
-    t.integer "adjustment_cents", default: 0
+    t.decimal "amortization", precision: 15, scale: 2, default: "0.0"
+    t.decimal "interest", precision: 15, scale: 2, default: "0.0"
+    t.decimal "insurance", precision: 15, scale: 2, default: "0.0"
+    t.decimal "fees", precision: 15, scale: 2, default: "0.0"
+    t.decimal "monetary_correction", precision: 15, scale: 2, default: "0.0"
+    t.decimal "adjustment", precision: 15, scale: 2, default: "0.0"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["financing_id"], name: "index_payments_on_financing_id"

--- a/spec/decorators/financings/financing_decorator_spec.rb
+++ b/spec/decorators/financings/financing_decorator_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Financings::FinancingDecorator do
     let!(:payment) do
       create(:payment,
              financing: financing,
-             amortization_cents: 100,
-             monetary_correction_cents: 600)
+             amortization: 100,
+             monetary_correction: 600)
     end
 
     it 'returns the calculated outstanding_balance' do
@@ -51,7 +51,7 @@ RSpec.describe Financings::FinancingDecorator do
     let!(:payment) do
       create(:payment,
              financing: financing,
-             amortization_cents: 100)
+             amortization: 100)
     end
 
     it 'returns the total_amortization amount' do
@@ -63,7 +63,7 @@ RSpec.describe Financings::FinancingDecorator do
     let!(:payment) do
       create(:payment,
              financing: financing,
-             interest_cents: 400)
+             interest: 400)
     end
 
     it 'returns the total_interest_paid amount' do
@@ -99,7 +99,7 @@ RSpec.describe Financings::FinancingDecorator do
     let!(:payment) do
       create(:payment,
              financing: financing,
-             monetary_correction_cents: 500)
+             monetary_correction: 500)
     end
 
     it 'returns the monetary_correction amount' do

--- a/spec/decorators/financings/financing_decorator_spec.rb
+++ b/spec/decorators/financings/financing_decorator_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe Financings::FinancingDecorator do
+  subject(:decorate_financing) { financing.decorate }
+
+  let(:financing) do
+    create(:financing,
+           borrowed_value: 15.00,
+           installments: 10,
+           name: 'financing')
+  end
+
+  describe '#borrowed_value' do
+    it 'returns the borrowed_value in the correct format' do
+      expect(decorate_financing.borrowed_value).to eq('R$ 15,00')
+    end
+  end
+
+  describe '#name' do
+    it 'returns the capitalized name' do
+      expect(decorate_financing.name).to eq('Financing')
+    end
+  end
+
+  describe '#outstanding_parcels' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             paid_parcels: 2)
+    end
+
+    it 'returns the outstanding_parcels' do
+      expect(decorate_financing.outstanding_parcels).to eq(8)
+    end
+  end
+
+  describe '#outstanding_balance' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             amortization_cents: 100,
+             monetary_correction_cents: 600)
+    end
+
+    it 'returns the calculated outstanding_balance' do
+      expect(decorate_financing.outstanding_balance).to eq('R$ 515,00')
+    end
+  end
+
+  describe '#total_amortization' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             amortization_cents: 100)
+    end
+
+    it 'returns the total_amortization amount' do
+      expect(decorate_financing.total_amortization).to eq('R$ 100,00')
+    end
+  end
+
+  describe '#total_interest_paid' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             interest_cents: 400)
+    end
+
+    it 'returns the total_interest_paid amount' do
+      expect(decorate_financing.total_interest_paid).to eq('R$ 400,00')
+    end
+  end
+
+  describe '#ordinary_parcels' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             ordinary: true)
+    end
+
+    it 'returns the ordinary_parcels amount' do
+      expect(decorate_financing.ordinary_parcels).to eq(1)
+    end
+  end
+
+  describe '#non_ordinary_parcels' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             ordinary: false)
+    end
+
+    it 'returns the non_ordinary_parcels amount' do
+      expect(decorate_financing.non_ordinary_parcels).to eq(1)
+    end
+  end
+
+  describe '#monetary_correction' do
+    let!(:payment) do
+      create(:payment,
+             financing: financing,
+             monetary_correction_cents: 500)
+    end
+
+    it 'returns the monetary_correction amount' do
+      expect(decorate_financing.monetary_correction).to eq('R$ 500,00')
+    end
+  end
+end

--- a/spec/decorators/financings/payment_decorator_spec.rb
+++ b/spec/decorators/financings/payment_decorator_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Financings::PaymentDecorator do
            paid_parcels: 1,
            ordinary: 'true',
            payment_date: '2024-02-02'.to_date,
-           amortization_cents: 100,
-           fees_cents: 200,
-           interest_cents: 300,
-           insurance_cents: 400,
-           adjustment_cents: 500,
-           monetary_correction_cents: 600)
+           amortization: 100,
+           fees: 200,
+           interest: 300,
+           insurance: 400,
+           adjustment: 500,
+           monetary_correction: 600)
   end
 
   describe '#parcel_value' do

--- a/spec/factories/financing.rb
+++ b/spec/factories/financing.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :financing, class: 'Financings::Financing' do
     sequence(:name) { "Financing_#{_1}" }
-    borrowed_value_cents { Random.rand(1000..100_000) }
+    borrowed_value { Random.rand(1000..100_000) }
     installments { Random.rand(1..100) }
     user
   end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -5,12 +5,12 @@ FactoryBot.define do
     parcel { SecureRandom.random_number(1..360) }
     paid_parcels { SecureRandom.random_number(1..360) }
     payment_date { Time.zone.today }
-    amortization_cents { SecureRandom.random_number(1_000..100_000_000) }
-    interest_cents { SecureRandom.random_number(1_000..100_000_000) }
-    insurance_cents { SecureRandom.random_number(1_000..100_000_000) }
-    fees_cents { SecureRandom.random_number(1_000..100_000_000) }
-    monetary_correction_cents { SecureRandom.random_number(1_000..100_000_000) }
-    adjustment_cents { SecureRandom.random_number(1_000..100_000_000) }
+    amortization { SecureRandom.random_number(1_000..100_000_000) }
+    interest { SecureRandom.random_number(1_000..100_000_000) }
+    insurance { SecureRandom.random_number(1_000..100_000_000) }
+    fees { SecureRandom.random_number(1_000..100_000_000) }
+    monetary_correction { SecureRandom.random_number(1_000..100_000_000) }
+    adjustment { SecureRandom.random_number(1_000..100_000_000) }
 
     trait :non_ordinary do
       ordinary { false }

--- a/spec/requests/financing_spec.rb
+++ b/spec/requests/financing_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Financings::Financing' do
       it 'creates a new Financing' do
         expect do
           post financings_path, params: { financing: { name: 'First',
-                                                       borrowed_value_cents: '1',
+                                                       borrowed_value: '1.23',
                                                        installments: 123 } }
         end.to change(Financings::Financing, :count).by(1)
       end

--- a/spec/services/financing_services/create_payment_spec.rb
+++ b/spec/services/financing_services/create_payment_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe FinancingServices::CreatePayment do
           paid_parcels: 1,
           ordinary: 'true',
           payment_date: Date.current,
-          amortization: '12,34',
-          fees: '56,78',
-          interest: '90,12',
-          insurance: '34,56',
-          adjustment: '78,90',
-          monetary_correction: '12,34'
+          amortization: '12.34',
+          fees: '56.78',
+          interest: '90.12',
+          insurance: '34.56',
+          adjustment: '78.90',
+          monetary_correction: '12.34'
         }
       end
 
-      it 'create and return the installment' do
+      it 'create and return the installment', :aggregate_failures do
         response = create_installment
 
         expect(response).to be_persisted
@@ -31,12 +31,12 @@ RSpec.describe FinancingServices::CreatePayment do
         expect(response.parcel).to eq(1)
         expect(response.paid_parcels).to eq(1)
         expect(response.ordinary).to be true
-        expect(response.amortization_cents).to eq(1234)
-        expect(response.fees_cents).to eq(5678)
-        expect(response.interest_cents).to eq(9012)
-        expect(response.insurance_cents).to eq(3456)
-        expect(response.adjustment_cents).to eq(7890)
-        expect(response.monetary_correction_cents).to eq(1234)
+        expect(response.amortization).to eq(12.34)
+        expect(response.fees).to eq(56.78)
+        expect(response.interest).to eq(90.12)
+        expect(response.insurance).to eq(34.56)
+        expect(response.adjustment).to eq(78.90)
+        expect(response.monetary_correction).to eq(12.34)
       end
     end
 

--- a/spec/services/financing_services/update_financing_spec.rb
+++ b/spec/services/financing_services/update_financing_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FinancingServices::UpdateFinancing do
         {
           user_id: financing.user_id,
           name: 'Updated Financing',
-          borrowed_value_cents: 12.34,
+          borrowed_value: '12.34',
           installments: 10
         }
       end
@@ -22,7 +22,7 @@ RSpec.describe FinancingServices::UpdateFinancing do
         expect(response).to be_persisted
         expect(response).to be_a(Financings::Financing)
         expect(response.name).to eq('Updated Financing')
-        expect(response.borrowed_value_cents).to eq(1234)
+        expect(response.borrowed_value).to eq(12.34)
         expect(response.installments).to eq(10)
       end
     end

--- a/spec/services/financing_services/update_payment_spec.rb
+++ b/spec/services/financing_services/update_payment_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe FinancingServices::UpdatePayment do
           paid_parcels: 1,
           ordinary: 'false',
           payment_date: Date.current,
-          amortization: '12,34',
-          fees: '56,78',
-          interest: '90,12',
-          insurance: '34,56',
-          adjustment: '78,90',
-          monetary_correction: '12,34'
+          amortization: '12.34',
+          fees: '56.78',
+          interest: '90.12',
+          insurance: '34.56',
+          adjustment: '78.90',
+          monetary_correction: '12.34'
         }
       end
 
-      it 'update and return the payment' do
+      it 'update and return the payment', :aggregate_failures do
         response = update_payment
 
         expect(response).to be_persisted
@@ -31,12 +31,12 @@ RSpec.describe FinancingServices::UpdatePayment do
         expect(response.parcel).to eq(0)
         expect(response.paid_parcels).to eq(1)
         expect(response.ordinary).to be false
-        expect(response.amortization_cents).to eq(1234)
-        expect(response.fees_cents).to eq(5678)
-        expect(response.interest_cents).to eq(9012)
-        expect(response.insurance_cents).to eq(3456)
-        expect(response.adjustment_cents).to eq(7890)
-        expect(response.monetary_correction_cents).to eq(1234)
+        expect(response.amortization).to eq(12.34)
+        expect(response.fees).to eq(56.78)
+        expect(response.interest).to eq(90.12)
+        expect(response.insurance).to eq(34.56)
+        expect(response.adjustment).to eq(78.90)
+        expect(response.monetary_correction).to eq(12.34)
       end
     end
   end


### PR DESCRIPTION
close #91 

Refactor payments to use decimal instead of integers and rename columns.