### PR TITLE
Refactor transactions to use decimal

### DIFF
--- a/app/controllers/account/transactions_controller.rb
+++ b/app/controllers/account/transactions_controller.rb
@@ -49,7 +49,7 @@ module Account
     private
 
     def transactions_params
-      params.require(:transaction).permit(:title, :category_id, :value, :kind, :date, :future, :parcels)
+      params.require(:transaction).permit(:title, :category_id, :amount, :kind, :date, :future, :parcels)
             .merge(account_id: params[:account_id])
     end
 

--- a/app/decorators/account/transaction_decorator.rb
+++ b/app/decorators/account/transaction_decorator.rb
@@ -2,8 +2,8 @@ module Account
   class TransactionDecorator < Draper::Decorator
     delegate_all
 
-    def value
-      object.value_cents / 100.0
+    def amount
+      ActionController::Base.helpers.number_to_currency(object.amount, unit: 'R$ ', separator: ',', delimiter: '.')
     end
 
     def date

--- a/app/services/account_services/build_transaction.rb
+++ b/app/services/account_services/build_transaction.rb
@@ -23,7 +23,7 @@ module AccountServices
     def transaction_params
       {
         account_id: params[:account_id],
-        value_cents: value_to_cents(params[:value]),
+        amount: value_to_decimal(params[:value]),
         kind: params[:kind].to_i,
         date: date,
         category_id: params[:category_id],
@@ -32,8 +32,8 @@ module AccountServices
       }
     end
 
-    def value_to_cents(value)
-      (value.to_f * 100).to_i
+    def value_to_decimal(value)
+      value.to_d
     end
 
     def date

--- a/app/services/account_services/consolidate_account_report.rb
+++ b/app/services/account_services/consolidate_account_report.rb
@@ -59,15 +59,15 @@ module AccountServices
     end
 
     def month_income(report)
-      report.transactions.where(kind: 'income').sum(:value_cents)
+      report.transactions.where(kind: 'income').sum(:amount)
     end
 
     def month_expense(report)
-      report.transactions.where(kind: 'expense').sum(:value_cents)
+      report.transactions.where(kind: 'expense').sum(:amount)
     end
 
     def month_invested(report)
-      report.transactions.where(kind: 'investment').sum(:value_cents)
+      report.transactions.where(kind: 'investment').sum(:amount)
     end
 
     def month_dividends

--- a/app/services/account_services/update_account_balance.rb
+++ b/app/services/account_services/update_account_balance.rb
@@ -34,7 +34,7 @@ module AccountServices
     end
 
     def new_balance
-      account.balance_cents + params[:value_cents]
+      account.balance_cents + params[:amount]
     end
   end
 end

--- a/app/services/credit_services/process_invoice_payment.rb
+++ b/app/services/credit_services/process_invoice_payment.rb
@@ -27,8 +27,8 @@ module CreditServices
       @receiver ||= Account::Account.find(params[:receiver_id])
     end
 
-    def value
-      @value ||= params.fetch(:value, 0).to_f
+    def amount
+      @amount ||= params.fetch(:amount, 0).to_d
     end
 
     def date
@@ -41,7 +41,7 @@ module CreditServices
 
     def sender_params
       { account_id: params[:sender_id],
-        value: value,
+        amount: amount,
         kind: EXPENSE_CODE,
         title: "#{I18n.t('invoice.invoice_payment')} - #{receiver.name}",
         date: date }
@@ -49,7 +49,7 @@ module CreditServices
 
     def receiver_params
       { account_id: receiver.id,
-        value: value,
+        amount: amount,
         kind: INCOME_CODE,
         title: I18n.t('invoice.invoice_payment'),
         date: date }

--- a/app/services/investments_services/create_dividend.rb
+++ b/app/services/investments_services/create_dividend.rb
@@ -46,7 +46,7 @@ module InvestmentsServices
 
     def transaction_params
       { account_id: investment.account_id,
-        value: params[:amount_cents].to_f * params[:shares].to_i,
+        amount: params[:amount_cents].to_f * params[:shares].to_i,
         kind: INCOME_CODE,
         title: "#{I18n.t('investments.dividends.dividends')} - #{investment.name}",
         date: date }

--- a/app/services/investments_services/create_fixed_investment.rb
+++ b/app/services/investments_services/create_fixed_investment.rb
@@ -17,7 +17,6 @@ module InvestmentsServices
     attr_reader :params
 
     def create_fixed_investment
-      # binding.pry
       Investments::FixedInvestment.create(attributes)
     end
 

--- a/app/services/transaction_services/build_transaction_parcels.rb
+++ b/app/services/transaction_services/build_transaction_parcels.rb
@@ -22,7 +22,7 @@ module TransactionServices
         category_id: category_id(params.fetch(:category)),
         account_id: account_id(params.fetch(:account)),
         kind: params.fetch(:kind),
-        value: params.fetch(:value).to_f / params[:parcels].to_i,
+        amount: params.fetch(:amount).to_d / params[:parcels].to_i,
         date: calculate_date(params[:date], parcel)
       }
     end

--- a/app/services/transaction_services/process_transaction_request.rb
+++ b/app/services/transaction_services/process_transaction_request.rb
@@ -34,8 +34,8 @@ module TransactionServices
       AccountServices::BuildTransaction.build(params)
     end
 
-    def value_to_cents(value)
-      (value.to_f * 100).to_i
+    def value_to_decimal(value)
+      value.to_d
     end
 
     def update_account_balance
@@ -45,7 +45,7 @@ module TransactionServices
     def update_account_balance_params
       {
         account_id: params[:account_id],
-        value_cents: value_to_update_balance
+        amount: value_to_update_balance
       }
     end
 
@@ -53,10 +53,10 @@ module TransactionServices
       value = if params.key?(:value_to_update_balance)
                 params[:value_to_update_balance]
               else
-                params[:value]
+                params[:amount]
               end
 
-      params[:kind].to_i.in?([0, 3]) ? -value_to_cents(value) : value_to_cents(value)
+      params[:kind].to_i.in?([0, 3]) ? -value_to_decimal(value) : value_to_decimal(value)
     end
 
     def consolidate_account_report(transaction)

--- a/app/services/transaction_services/transaction_request_builder.rb
+++ b/app/services/transaction_services/transaction_request_builder.rb
@@ -30,7 +30,7 @@ module TransactionServices
         category: category_name(params.fetch(:category_id)),
         account: account_name(params.fetch(:account_id)),
         kind: params.fetch(:kind),
-        value: params.fetch(:value),
+        amount: params.fetch(:amount),
         date: params[:date],
         parcels: params[:parcels]
       }

--- a/app/services/transference_services/process_transference_request.rb
+++ b/app/services/transference_services/process_transference_request.rb
@@ -37,7 +37,7 @@ module TransferenceServices
       {
         account_id: params[:sender_id],
         kind: TRANSFERENCE_CODE,
-        value: params[:value_cents],
+        amount: params[:value_cents],
         date: params[:date],
         category_id: nil,
         title: "Transferência para #{account(params[:receiver_id]).name}",
@@ -49,7 +49,7 @@ module TransferenceServices
       {
         account_id: params[:receiver_id],
         kind: TRANSFERENCE_CODE,
-        value: params[:value_cents],
+        amount: params[:value_cents],
         date: params[:date],
         category_id: nil,
         title: "Transferência de #{account(params[:sender_id]).name}",

--- a/app/views/account/transactions/_form.html.erb
+++ b/app/views/account/transactions/_form.html.erb
@@ -7,7 +7,7 @@
 
   <%= f.input :title, label: t('transactions.form.description'), input_html: { autofocus: true } %>
   <%= f.input :value, as: :integer, label: t('transactions.form.amount'),
-    input_html: { value: transaction.value_cents.present? ? (transaction.value_cents.to_f / 100.0) : 1,
+    input_html: { value: transaction.amount.present? ? transaction.amount.to_d : 1,
      readonly: !transaction.new_record? } %>
   <%= f.input :date, as: :date, html5: true, label: t('transactions.form.date') %>
   <%= f.input :category_id, label: t('transactions.form.category'), as: :select,

--- a/app/views/account/transactions/_transaction.html.erb
+++ b/app/views/account/transactions/_transaction.html.erb
@@ -4,7 +4,7 @@
     <%= transaction.title %>
   </div>
   <div>
-    R$ <%= transaction.value %>
+    R$ <%= transaction.amount %>
   </div>
 
   <div>

--- a/db/migrate/20240809123255_change_value_cents_to_decimal_in_transactions.rb
+++ b/db/migrate/20240809123255_change_value_cents_to_decimal_in_transactions.rb
@@ -1,0 +1,9 @@
+class ChangeValueCentsToDecimalInTransactions < ActiveRecord::Migration[7.0]
+  def up
+    change_column :transactions, :value_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :transactions, :value_cents, :integer
+  end
+end

--- a/db/migrate/20240809123537_rename_value_cents_in_transactions.rb
+++ b/db/migrate/20240809123537_rename_value_cents_in_transactions.rb
@@ -1,0 +1,9 @@
+class RenameValueCentsInTransactions < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :transactions, :value_cents, :amount
+  end
+
+  def down
+    rename_column :transactions, :amount, :value_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_30_021809) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_09_123537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -126,7 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_021809) do
     t.bigint "account_id", null: false
     t.bigint "account_report_id"
     t.bigint "category_id"
-    t.integer "value_cents", default: 0, null: false
+    t.decimal "amount", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "kind", default: 0, null: false
     t.string "title", null: false
     t.date "date"

--- a/spec/decorators/account/transaction_decorator_spec.rb
+++ b/spec/decorators/account/transaction_decorator_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Account::TransactionDecorator do
   subject(:decorated_transaction) { transaction.decorate }
 
-  describe '#value' do
-    let(:transaction) { create(:transaction, value_cents: 1234) }
+  describe '#amount' do
+    let(:transaction) { create(:transaction, amount: 12.34) }
 
     it 'returns the amount in the correct format' do
-      expect(decorated_transaction.value).to eq(12.34)
+      expect(decorated_transaction.amount).to eq('R$ 12,34')
     end
   end
 

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     account
     account_report
     category_id { create(:category).id }
-    value_cents { rand(1.0..1000.0).round(2) }
+    amount { rand(1.0..1000.0).round(2) }
     kind { 'income' }
     sequence(:title) { "Transaction_#{_1}" }
     date { Time.zone.today }

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Financings::Transaction' do
           post account_transactions_path(account_id: account.id), params: { transaction: {
             title: 'Transaction',
             date: '2024-01-01',
-            value: '100.01',
+            amount: '100.01',
             kind: 0,
             category_id: 2,
             parcels: 1

--- a/spec/services/account_services/build_transaction_spec.rb
+++ b/spec/services/account_services/build_transaction_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AccountServices::BuildTransaction do
     expect(response).to be_a(Account::Transaction)
     expect(response.kind).to eq('income')
     expect(response.title).to eq('My Transaction')
-    expect(response.value_cents).to eq(12_345)
+    expect(response.amount).to eq(123.45)
     expect(response).not_to be_persisted
     expect(response.account_report_id).not_to be_nil
     expect(response.date).to eq(Date.parse('2024-01-01'))

--- a/spec/services/account_services/update_account_balance_spec.rb
+++ b/spec/services/account_services/update_account_balance_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe AccountServices::UpdateAccountBalance do
   subject(:update_account_balance) { described_class.call(params) }
 
   let(:account) { create(:account, balance_cents: 123) }
-  let(:value) { -100 }
+  let(:amount) { -100 }
   let(:params) do
     {
       account_id: account.id,
-      value_cents: value
+      amount: amount
     }
   end
 

--- a/spec/services/credit_services/process_invoice_payment_spec.rb
+++ b/spec/services/credit_services/process_invoice_payment_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe CreditServices::ProcessInvoicePayment do
   subject(:service) { described_class.call(params) }
 
   let(:params) do
-    { sender_id: sender.id, receiver_id: receiver.id, value: '100', date: '2001-01-01' }
+    { sender_id: sender.id, receiver_id: receiver.id, amount: '100.01', date: '2001-01-01' }
   end
-  let(:sender) { create(:account, balance_cents: 15_000) }
+  let(:sender) { create(:account, balance_cents: 0) }
   let(:receiver) { create(:account, balance_cents: 0) }
 
   it 'processes the invoice payment', :aggregate_failures do
     expect { service }.to change(Account::Transaction, :count).by(2)
-    expect(sender.reload.balance_cents).to eq(5000)
-    expect(receiver.reload.balance_cents).to eq(10_000)
+    expect(sender.reload.balance_cents).to eq(-100)
+    expect(receiver.reload.balance_cents).to eq(100)
   end
 end

--- a/spec/services/transaction_services/process_transaction_request_spec.rb
+++ b/spec/services/transaction_services/process_transaction_request_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe TransactionServices::ProcessTransactionRequest do
   subject(:process_transaction_request) { described_class.call(params) }
 
-  let(:account) { create(:account, balance_cents: 12_346) }
+  let(:account) { create(:account, balance_cents: 1.00) }
 
   context 'when the transaction is an income' do
     let(:params) do
       {
         account_id: account.id,
-        value: '123.45',
+        amount: '123.45',
         kind: 1,
         category_id: nil,
         title: 'My Transaction',
@@ -26,7 +26,7 @@ RSpec.describe TransactionServices::ProcessTransactionRequest do
 
       account.reload
 
-      expect(account.balance_cents).to eq(24_691)
+      expect(account.balance_cents).to eq(124)
     end
   end
 

--- a/spec/services/transference_services/process_transference_request_spec.rb
+++ b/spec/services/transference_services/process_transference_request_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe TransferenceServices::ProcessTransferenceRequest do
     it 'updates the account balance' do
       service.call
 
-      expect(sender_account.reload.balance_cents).to eq(100)
-      expect(receiver_account.reload.balance_cents).to eq(323)
+      expect(sender_account.reload.balance_cents).to eq(221)
+      expect(receiver_account.reload.balance_cents).to eq(201)
     end
   end
 


### PR DESCRIPTION
closes #98 

Refactor transactions to use decimal instead of integer and rename column to amount.