### PR TITLE
Refactor account reports to use decimal

### DIFF
--- a/app/decorators/account/account_report_decorator.rb
+++ b/app/decorators/account/account_report_decorator.rb
@@ -3,31 +3,35 @@ module Account
     delegate_all
 
     def initial_account_balance
-      (object.initial_account_balance_cents.presence || 0) / 100.0
+      format_currency(object.initial_account_balance)
     end
 
     def final_account_balance
-      (object.final_account_balance_cents.presence || 0) / 100.0
+      format_currency(object.final_account_balance.presence || 0)
     end
 
     def month_balance
-      object.month_balance_cents / 100.0
+      format_currency(object.month_balance)
     end
 
     def month_income
-      object.month_income_cents / 100.0
+      format_currency(object.month_income)
     end
 
     def month_expense
-      object.month_expense_cents / 100.0
+      format_currency(object.month_expense)
     end
 
     def month_invested
-      object.month_invested_cents / 100.0
+      format_currency(object.month_invested)
     end
 
     def month_dividends
-      object.month_dividends_cents / 100.0
+      format_currency(object.month_dividends)
+    end
+
+    def format_currency(value)
+      ActionController::Base.helpers.number_to_currency(value, unit: 'R$ ', separator: ',', delimiter: '.')
     end
   end
 end

--- a/app/services/account_services/consolidate_account_report.rb
+++ b/app/services/account_services/consolidate_account_report.rb
@@ -34,20 +34,20 @@ module AccountServices
 
     def consolidate(report)
       {
-        initial_account_balance_cents: initial_account_balance,
-        final_account_balance_cents: final_account_balance,
-        month_balance_cents: month_balance(report),
-        month_income_cents: month_income(report),
-        month_expense_cents: month_expense(report),
-        month_invested_cents: month_invested(report),
-        month_dividends_cents: month_dividends
+        initial_account_balance: initial_account_balance,
+        final_account_balance: final_account_balance,
+        month_balance: month_balance(report),
+        month_income: month_income(report),
+        month_expense: month_expense(report),
+        month_invested: month_invested(report),
+        month_dividends: month_dividends
       }
     end
 
     def initial_account_balance
       return 0 if past_month_report.nil?
 
-      past_month_report.final_account_balance_cents
+      past_month_report.final_account_balance
     end
 
     def final_account_balance
@@ -103,13 +103,13 @@ module AccountServices
 
     def default_account_report_attributes
       {
-        initial_account_balance_cents: 0,
-        final_account_balance_cents: 0,
-        month_balance_cents: 0,
-        month_income_cents: 0,
-        month_expense_cents: 0,
-        month_invested_cents: 0,
-        month_dividends_cents: 0,
+        initial_account_balance: 0,
+        final_account_balance: 0,
+        month_balance: 0,
+        month_income: 0,
+        month_expense: 0,
+        month_invested: 0,
+        month_dividends: 0,
         reference: current_reference
       }
     end

--- a/app/services/account_services/create_account_report.rb
+++ b/app/services/account_services/create_account_report.rb
@@ -31,19 +31,19 @@ module AccountServices
       {
         date: date,
         reference: reference,
-        initial_account_balance_cents: past_month_final_account_balance,
-        final_account_balance_cents: 0,
-        month_balance_cents: 0,
-        month_income_cents: 0,
-        month_expense_cents: 0,
-        month_invested_cents: 0,
-        month_dividends_cents: 0
+        initial_account_balance: past_month_final_account_balance,
+        final_account_balance: 0,
+        month_balance: 0,
+        month_income: 0,
+        month_expense: 0,
+        month_invested: 0,
+        month_dividends: 0
       }
     end
 
     def past_month_final_account_balance
       past_month_reference_date = date.prev_month
-      account.month_report(past_month_reference_date)&.final_account_balance_cents || 0
+      account.month_report(past_month_reference_date)&.final_account_balance || 0
     end
 
     def reference

--- a/app/services/account_services/create_past_reports_chart_data.rb
+++ b/app/services/account_services/create_past_reports_chart_data.rb
@@ -16,17 +16,13 @@ module AccountServices
 
     attr_reader :reports
 
-    def convert_to_float(cents)
-      cents / 100.0
-    end
-
     def mount_summary
       summary = { incomes: {}, expenses: {}, invested: {}, balances: {} }
       reports.each do |report|
-        summary[:incomes][report.date.strftime('%B-%Y').to_s] = convert_to_float(report.month_income_cents)
-        summary[:expenses][report.date.strftime('%B-%Y').to_s] = convert_to_float(report.month_expense_cents)
-        summary[:invested][report.date.strftime('%B-%Y').to_s] = convert_to_float(report.month_invested_cents)
-        summary[:balances][report.date.strftime('%B-%Y').to_s] = convert_to_float(report.month_balance_cents)
+        summary[:incomes][report.date.strftime('%B-%Y').to_s] = report.month_income
+        summary[:expenses][report.date.strftime('%B-%Y').to_s] = report.month_expense
+        summary[:invested][report.date.strftime('%B-%Y').to_s] = report.month_invested
+        summary[:balances][report.date.strftime('%B-%Y').to_s] = report.month_balance
       end
       summary
     end

--- a/app/services/user_services/consolidated_user_report.rb
+++ b/app/services/user_services/consolidated_user_report.rb
@@ -59,14 +59,14 @@ module UserServices
         account_report = account.current_report
         @savings_cents += account.balance
         @investments_cents += calculate_investments(account)
-        @incomes_cents += account_report.month_income_cents
-        @expenses_cents += account_report.month_expense_cents
-        @invested_cents += account_report.month_invested_cents
-        @dividends_cents += account_report.month_dividends_cents
+        @incomes_cents += account_report.month_income
+        @expenses_cents += account_report.month_expense
+        @invested_cents += account_report.month_invested
+        @dividends_cents += account_report.month_dividends
       end
 
       user.accounts.card_accounts.each do |card|
-        @card_expenses_cents += card.current_report.month_expense_cents
+        @card_expenses_cents += card.current_report.month_expense
       end
 
       @balance_cents = @incomes_cents - @expenses_cents - @invested_cents

--- a/app/services/user_services/fetch_user_cards_summary.rb
+++ b/app/services/user_services/fetch_user_cards_summary.rb
@@ -19,7 +19,7 @@ module UserServices
           id: card.id,
           name: card.name,
           balance: calculate_month_balance(card),
-          total: convert_to_float(card.balance)
+          total: card.balance
         }
       end
     end
@@ -28,13 +28,10 @@ module UserServices
 
     attr_reader :user_id
 
-    def convert_to_float(cents)
-      cents / 100.0
-    end
-
     def calculate_month_balance(card)
+      # binding.pry
       current_report = card.current_report
-      convert_to_float(current_report.month_income_cents - current_report.month_expense_cents)
+      current_report.month_income - current_report.month_expense
     end
   end
 end

--- a/db/migrate/20240809150109_change_integer_columns_to_decimal_in_account_reports.rb
+++ b/db/migrate/20240809150109_change_integer_columns_to_decimal_in_account_reports.rb
@@ -1,0 +1,21 @@
+class ChangeIntegerColumnsToDecimalInAccountReports < ActiveRecord::Migration[7.0]
+  def up
+    change_column :account_reports, :initial_account_balance_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :final_account_balance_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :month_balance_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :month_income_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :month_expense_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :month_invested_cents, :decimal, precision: 15, scale: 2
+    change_column :account_reports, :month_dividends_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :account_reports, :initial_account_balance_cents, :integer
+    change_column :account_reports, :final_account_balance_cents, :integer
+    change_column :account_reports, :month_balance_cents, :integer
+    change_column :account_reports, :month_income_cents, :integer
+    change_column :account_reports, :month_expense_cents, :integer
+    change_column :account_reports, :month_invested_cents, :integer
+    change_column :account_reports, :month_dividends_cents, :integer
+  end
+end

--- a/db/migrate/20240809150559_rename_columns_in_account_reports.rb
+++ b/db/migrate/20240809150559_rename_columns_in_account_reports.rb
@@ -1,0 +1,21 @@
+class RenameColumnsInAccountReports < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :account_reports, :initial_account_balance_cents, :initial_account_balance
+    rename_column :account_reports, :final_account_balance_cents, :final_account_balance
+    rename_column :account_reports, :month_balance_cents, :month_balance
+    rename_column :account_reports, :month_income_cents, :month_income
+    rename_column :account_reports, :month_expense_cents, :month_expense
+    rename_column :account_reports, :month_invested_cents, :month_invested
+    rename_column :account_reports, :month_dividends_cents, :month_dividends
+  end
+
+  def down
+    rename_column :account_reports, :initial_account_balance, :initial_account_balance_cents
+    rename_column :account_reports, :final_account_balance, :final_account_balance_cents
+    rename_column :account_reports, :month_balance, :month_balance_cents
+    rename_column :account_reports, :month_income, :month_income_cents
+    rename_column :account_reports, :month_expense, :month_expense_cents
+    rename_column :account_reports, :month_invested, :month_invested_cents
+    rename_column :account_reports, :month_dividends, :month_dividends_cents
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_09_123537) do
-
+ActiveRecord::Schema[7.0].define(version: 2024_08_09_150559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "account_reports", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.date "date"
-    t.integer "initial_account_balance_cents", default: 0, null: false
-    t.integer "final_account_balance_cents", default: 0, null: false
-    t.integer "month_balance_cents", default: 0, null: false
-    t.integer "month_income_cents", default: 0, null: false
-    t.integer "month_expense_cents", default: 0, null: false
-    t.integer "month_invested_cents", default: 0, null: false
-    t.integer "month_dividends_cents", default: 0, null: false
+    t.decimal "initial_account_balance", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "final_account_balance", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "month_balance", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "month_income", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "month_expense", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "month_invested", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "month_dividends", precision: 15, scale: 2, default: "0.0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "reference"

--- a/spec/decorators/account/account_report_decorator_spec.rb
+++ b/spec/decorators/account/account_report_decorator_spec.rb
@@ -3,47 +3,56 @@ require 'rails_helper'
 RSpec.describe Account::AccountReportDecorator do
   subject(:decorate_account_report) { account_report.decorate }
 
-  let(:account_report) { create(:account_report) }
+  let(:account_report) do
+    create(:account_report,
+           initial_account_balance: 1.23,
+           final_account_balance: 2.34,
+           month_balance: 3.45,
+           month_income: 4.56,
+           month_expense: 5.67,
+           month_invested: 6.78,
+           month_dividends: 7.89)
+  end
 
   describe '#initial_account_balance' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.initial_account_balance).to eq(account_report.initial_account_balance_cents / 100.0)
+      expect(decorate_account_report.initial_account_balance).to eq('R$ 1,23')
     end
   end
 
   describe '#final_account_balance' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.final_account_balance).to eq(account_report.final_account_balance_cents / 100.0)
+      expect(decorate_account_report.final_account_balance).to eq('R$ 2,34')
     end
   end
 
   describe '#month_balance' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.month_balance).to eq(account_report.month_balance_cents / 100.0)
+      expect(decorate_account_report.month_balance).to eq('R$ 3,45')
     end
   end
 
   describe '#month_income' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.month_income).to eq(account_report.month_income_cents / 100.0)
+      expect(decorate_account_report.month_income).to eq('R$ 4,56')
     end
   end
 
   describe '#month_expense' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.month_expense).to eq(account_report.month_expense_cents / 100.0)
+      expect(decorate_account_report.month_expense).to eq('R$ 5,67')
     end
   end
 
   describe '#month_invested' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.month_invested).to eq(account_report.month_invested_cents / 100.0)
+      expect(decorate_account_report.month_invested).to eq('R$ 6,78')
     end
   end
 
   describe '#month_dividends' do
     it 'returns the balance in the correct format' do
-      expect(decorate_account_report.month_dividends).to eq(account_report.month_dividends_cents / 100.0)
+      expect(decorate_account_report.month_dividends).to eq('R$ 7,89')
     end
   end
 end

--- a/spec/factories/account_report.rb
+++ b/spec/factories/account_report.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :account_report, class: 'Account::AccountReport' do
     account
     date { Time.zone.today }
-    initial_account_balance_cents { rand(1000..100_000) }
-    final_account_balance_cents { rand(1000..100_000) }
-    month_balance_cents { rand(1000..100_000) }
-    month_income_cents { rand(1000..100_000) }
-    month_expense_cents { rand(1000..100_000) }
-    month_invested_cents { rand(1000..100_000) }
-    month_dividends_cents { rand(1000..100_000) }
+    initial_account_balance { rand(1000..100_000) }
+    final_account_balance { rand(1000..100_000) }
+    month_balance { rand(1000..100_000) }
+    month_income { rand(1000..100_000) }
+    month_expense { rand(1000..100_000) }
+    month_invested { rand(1000..100_000) }
+    month_dividends { rand(1000..100_000) }
     reference { Time.zone.now.strftime('%m%y').to_i }
   end
 end

--- a/spec/services/user_services/consolidated_user_report_spec.rb
+++ b/spec/services/user_services/consolidated_user_report_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe UserServices::ConsolidatedUserReport do
     create(:account_report,
            account: savings_account,
            date: Date.current,
-           initial_account_balance_cents: 1,
-           final_account_balance_cents: 2,
-           month_balance_cents: 3,
-           month_income_cents: 4,
-           month_expense_cents: 5,
-           month_invested_cents: 6,
-           month_dividends_cents: 7,
+           initial_account_balance: 1,
+           final_account_balance: 2,
+           month_balance: 3,
+           month_income: 4,
+           month_expense: 5,
+           month_invested: 6,
+           month_dividends: 7,
            reference: Date.current.strftime('%m%y'))
   end
   let(:broker_account) { create(:account, :broker, user: user, balance: 2) }
@@ -24,13 +24,13 @@ RSpec.describe UserServices::ConsolidatedUserReport do
     create(:account_report,
            account: broker_account,
            date: Date.current,
-           initial_account_balance_cents: 1,
-           final_account_balance_cents: 2,
-           month_balance_cents: 3,
-           month_income_cents: 4,
-           month_expense_cents: 5,
-           month_invested_cents: 6,
-           month_dividends_cents: 7,
+           initial_account_balance: 1,
+           final_account_balance: 2,
+           month_balance: 3,
+           month_income: 4,
+           month_expense: 5,
+           month_invested: 6,
+           month_dividends: 7,
            reference: Date.current.strftime('%m%y'))
   end
   let!(:fixed_investment) { create(:investment, account: broker_account, current_value_cents: 2) }

--- a/spec/services/user_services/fetch_user_cards_summary_spec.rb
+++ b/spec/services/user_services/fetch_user_cards_summary_spec.rb
@@ -7,19 +7,18 @@ RSpec.describe UserServices::FetchUserCardsSummary do
   let(:card) { create(:account, :card, user: user, balance: -2.00) }
   let!(:report) do
     create(:account_report, account: card,
-                            month_income_cents: 200,
-                            month_expense_cents: 100,
+                            month_income: 2.00,
+                            month_expense: 1.00,
                             reference: Date.current.strftime('%m%y'))
   end
 
-  it 'fetch the accounts summary', :aggregate_failures do
+  it 'fetch the cards summary', :aggregate_failures do
     response = service.call
 
     expect(response).to be_a(Array)
     expect(response[0][:id]).to eq(card.id)
     expect(response[0][:name]).to eq(card.name)
     expect(response[0][:balance]).to eq(1.00)
-    expect(response[0][:total]).to eq(-0.02)
-    # expect(response[0][:total]).to eq(card.balance)
+    expect(response[0][:total]).to eq(card.balance)
   end
 end


### PR DESCRIPTION
closes #93 

Refactor account_reports to use decimal instead of integer and rename columns.