### PR TITLE
Refactor dividends to use decimal

### DIFF
--- a/app/controllers/investments/dividends_controller.rb
+++ b/app/controllers/investments/dividends_controller.rb
@@ -32,7 +32,7 @@ module Investments
     private
 
     def dividend_params
-      params.require(:dividend).permit(:date, :amount_cents, :investment_id, :shares)
+      params.require(:dividend).permit(:date, :amount, :investment_id, :shares)
     end
   end
 end

--- a/app/decorators/investments/dividend_decorator.rb
+++ b/app/decorators/investments/dividend_decorator.rb
@@ -7,7 +7,7 @@ module Investments
     end
 
     def amount
-      object.amount_cents.to_f / 100
+      ActionController::Base.helpers.number_to_currency(object.amount, unit: 'R$ ', separator: ',', delimiter: '.')
     end
   end
 end

--- a/app/services/investments_services/create_dividend.rb
+++ b/app/services/investments_services/create_dividend.rb
@@ -24,14 +24,10 @@ module InvestmentsServices
     def formated_params
       {
         date: date,
-        amount_cents: convert_to_cents(params[:amount_cents]),
+        amount: params[:amount].to_d,
         shares: params[:shares],
         investment: investment
       }
-    end
-
-    def convert_to_cents(value)
-      value.to_f * 100
     end
 
     def date
@@ -46,7 +42,7 @@ module InvestmentsServices
 
     def transaction_params
       { account_id: investment.account_id,
-        amount: params[:amount_cents].to_f * params[:shares].to_i,
+        amount: params[:amount].to_d * params[:shares].to_i,
         kind: INCOME_CODE,
         title: "#{I18n.t('investments.dividends.dividends')} - #{investment.name}",
         date: date }

--- a/app/views/investments/dividends/_form.html.erb
+++ b/app/views/investments/dividends/_form.html.erb
@@ -6,7 +6,7 @@
   <%= form_error_notification(dividend) %>
 
   <%= f.input :date, label: t('investments.dividends.form.date'), as: :date, html5: true, input_html: { autofocus: true } %>
-  <%= f.input :amount_cents, as: :float, label: t('investments.dividends.form.amount') %>
+  <%= f.input :amount, as: :float, label: t('investments.dividends.form.amount') %>
   <%= f.input :shares, label: t('investments.dividends.form.shares'), as: :integer %>
   <%= f.input :investment_id, as: :hidden, input_html: { value: params[:investment_id] } %>
   <%= f.submit t('buttons.save'), class: "btn btn--secondary" %>

--- a/db/migrate/20240809165934_change_amount_cents_to_decimal_in_dividends.rb
+++ b/db/migrate/20240809165934_change_amount_cents_to_decimal_in_dividends.rb
@@ -1,0 +1,9 @@
+class ChangeAmountCentsToDecimalInDividends < ActiveRecord::Migration[7.0]
+  def up
+    change_column :dividends, :amount_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :dividends, :amount_cents, :integer
+  end
+end

--- a/db/migrate/20240809170029_rename_amount_cents_in_dividends.rb
+++ b/db/migrate/20240809170029_rename_amount_cents_in_dividends.rb
@@ -1,0 +1,9 @@
+class RenameAmountCentsInDividends < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :dividends, :amount_cents, :amount
+  end
+
+  def down
+    rename_column :dividends, :amount, :value_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_09_150559) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_09_170029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_09_150559) do
 
   create_table "dividends", force: :cascade do |t|
     t.bigint "investment_id", null: false
-    t.integer "amount_cents", default: 0, null: false
+    t.decimal "amount", precision: 15, scale: 2, default: "0.0", null: false
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/decorators/investments/dividend_decorator_spec.rb
+++ b/spec/decorators/investments/dividend_decorator_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe Investments::DividendDecorator do
   subject(:decorated_dividend) { dividend.decorate }
 
-  let(:dividend) { create(:dividend, date: '2024-03-16') }
+  let(:dividend) { create(:dividend, date: '2024-03-16', amount: 1.09) }
   let(:investment) { create(:investment, dividends: [dividend]) }
   let(:account) { create(:account, investments: [investment]) }
 
   describe '#amount' do
     it 'returns the amount' do
-      expect(decorated_dividend.amount).to eq(dividend.amount_cents / 100.0)
+      expect(decorated_dividend.amount).to eq('R$ 1,09')
     end
   end
 

--- a/spec/factories/dividend.rb
+++ b/spec/factories/dividend.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :dividend, class: 'investments::Dividend' do
     investment { create(:investment, :variable) }
-    amount_cents { rand(1.0..1000.0).round(2) }
+    amount { rand(1.0..1000.0).round(2) }
     date { Time.zone.today }
   end
 end

--- a/spec/services/investments_services/create_dividends_spec.rb
+++ b/spec/services/investments_services/create_dividends_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe InvestmentsServices::CreateDividend do
     let(:params) do
       {
         date: Date.current.strftime('%d/%m/%Y'),
-        amount_cents: '10.01',
+        amount: '10.01',
         investment_id: investment.id
       }
     end
@@ -20,7 +20,7 @@ RSpec.describe InvestmentsServices::CreateDividend do
 
       expect(response).to be_a(Investments::Dividend)
       expect(response.date).to eq(Date.current)
-      expect(response.amount_cents).to eq(1001)
+      expect(response.amount).to eq(10.01)
       expect(response.investment_id).to eq(investment.id)
       expect(response).to be_persisted
     end
@@ -30,7 +30,7 @@ RSpec.describe InvestmentsServices::CreateDividend do
     let(:params) do
       {
         date: '',
-        amount_cents: '10.01',
+        amount: '10.01',
         investment_id: investment.id
       }
     end
@@ -40,7 +40,7 @@ RSpec.describe InvestmentsServices::CreateDividend do
 
       expect(response).to be_a(Investments::Dividend)
       expect(response.date).to eq(Date.current)
-      expect(response.amount_cents).to eq(1001)
+      expect(response.amount).to eq(10.01)
       expect(response.investment_id).to eq(investment.id)
       expect(response).to be_persisted
     end


### PR DESCRIPTION
closes #94 

Refactor dividends to use decimal instead of integer and rename amount_cents column.