### PR TITLE
Refactor transferences to use decimal

### DIFF
--- a/app/controllers/transferences_controller.rb
+++ b/app/controllers/transferences_controller.rb
@@ -26,6 +26,6 @@ class TransferencesController < ApplicationController
   private
 
   def transference_params
-    params.require(:transference).permit(:sender_id, :receiver_id, :date, :value_cents).merge(user_id: current_user.id)
+    params.require(:transference).permit(:sender_id, :receiver_id, :date, :amount).merge(user_id: current_user.id)
   end
 end

--- a/app/decorators/transference_decorator.rb
+++ b/app/decorators/transference_decorator.rb
@@ -1,8 +1,8 @@
 class TransferenceDecorator < Draper::Decorator
   delegate_all
 
-  def value
-    object.value_cents / 100.0
+  def amount
+    ActionController::Base.helpers.number_to_currency(object.amount, unit: 'R$ ', separator: ',', delimiter: '.')
   end
 
   def date

--- a/app/models/transference.rb
+++ b/app/models/transference.rb
@@ -3,7 +3,7 @@ class Transference < ApplicationRecord
   belongs_to :receiver, class_name: 'Account::Account'
   belongs_to :user
 
-  validates :date, :value_cents, presence: true
+  validates :date, :amount, presence: true
   validate :different_accounts
 
   def different_accounts

--- a/app/services/transference_services/build_transference.rb
+++ b/app/services/transference_services/build_transference.rb
@@ -25,13 +25,9 @@ module TransferenceServices
         sender_id: params[:sender_id],
         receiver_id: params[:receiver_id],
         user_id: params[:user_id],
-        value_cents: value_to_cents(params[:value_cents]),
+        amount: params[:amount].to_d,
         date: date
       }
-    end
-
-    def value_to_cents(value)
-      (value.to_f * 100).to_i
     end
 
     def date

--- a/app/services/transference_services/process_transference_request.rb
+++ b/app/services/transference_services/process_transference_request.rb
@@ -37,11 +37,11 @@ module TransferenceServices
       {
         account_id: params[:sender_id],
         kind: TRANSFERENCE_CODE,
-        amount: params[:value_cents],
+        amount: params[:amount],
         date: params[:date],
         category_id: nil,
         title: "Transferência para #{account(params[:receiver_id]).name}",
-        value_to_update_balance: "-#{params[:value_cents]}"
+        value_to_update_balance: "-#{params[:amount]}"
       }
     end
 
@@ -49,11 +49,11 @@ module TransferenceServices
       {
         account_id: params[:receiver_id],
         kind: TRANSFERENCE_CODE,
-        amount: params[:value_cents],
+        amount: params[:amount],
         date: params[:date],
         category_id: nil,
         title: "Transferência de #{account(params[:sender_id]).name}",
-        value_to_update_balance: params[:value_cents]
+        value_to_update_balance: params[:amount]
       }
     end
 

--- a/app/views/transferences/_form.html.erb
+++ b/app/views/transferences/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for transference, html: { class: "transference form" }, data: { turbo: false }  do |f| %>
   <%= form_error_notification(transference) %>
 
-  <%= f.input :value_cents, as: :float, label: t('transference.form.amount'), input_html: { autofocus: true } %>
+  <%= f.input :amount, as: :float, label: t('transference.form.amount'), input_html: { autofocus: true } %>
   <%= f.input :date, as: :date, html5: true, label: t('transference.form.date') %>
   <%= f.input :sender_id, as: :select, collection: all_accounts(current_user.id), label: t('transference.form.sender') %>
   <%= f.input :receiver_id, as: :select, collection: all_accounts(current_user.id), label: t('transference.form.receiver') %>

--- a/app/views/transferences/_transference.html.erb
+++ b/app/views/transferences/_transference.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div>
-    R$ <%= transference.value %>
+    R$ <%= transference.amount %>
   </div>
 
 </div>

--- a/db/migrate/20240809182224_change_value_cents_to_decimal_in_transferences.rb
+++ b/db/migrate/20240809182224_change_value_cents_to_decimal_in_transferences.rb
@@ -1,0 +1,9 @@
+class ChangeValueCentsToDecimalInTransferences < ActiveRecord::Migration[7.0]
+  def up
+    change_column :transferences, :value_cents, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    change_column :transferences, :value_cents, :integer
+  end
+end

--- a/db/migrate/20240809182245_rename_value_cents_in_transferences.rb
+++ b/db/migrate/20240809182245_rename_value_cents_in_transferences.rb
@@ -1,0 +1,9 @@
+class RenameValueCentsInTransferences < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :transferences, :value_cents, :amount
+  end
+
+  def down
+    rename_column :transferences, :amount, :value_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_09_173817) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_09_182245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,7 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_09_173817) do
     t.bigint "receiver_id"
     t.bigint "user_id", null: false
     t.date "date", null: false
-    t.integer "value_cents", default: 0, null: false
+    t.decimal "amount", precision: 15, scale: 2, default: "0.0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["receiver_id"], name: "index_transferences_on_receiver_id"

--- a/spec/decorators/transference_decorator_spec.rb
+++ b/spec/decorators/transference_decorator_spec.rb
@@ -3,21 +3,19 @@ require 'rails_helper'
 RSpec.describe TransferenceDecorator do
   subject(:decorate_transference) { transference.decorate }
 
-  describe '#value' do
+  describe '#amount' do
     let(:transference) do
-      create(:transference,
-             value_cents: 1234)
+      create(:transference, amount: 12.34)
     end
 
     it 'returns the balance in the correct format' do
-      expect(decorate_transference.value).to eq(12.34)
+      expect(decorate_transference.amount).to eq('R$ 12,34')
     end
   end
 
   describe '#date' do
     let(:transference) do
-      create(:transference,
-             date: '2024-03-16')
+      create(:transference, date: '2024-03-16')
     end
 
     it 'returns the balance in the correct format' do
@@ -27,8 +25,7 @@ RSpec.describe TransferenceDecorator do
 
   describe '#sender' do
     let(:transference) do
-      create(:transference,
-             sender_id: sender.id)
+      create(:transference, sender_id: sender.id)
     end
 
     let(:sender) { create(:account, name: 'Sender') }
@@ -40,8 +37,7 @@ RSpec.describe TransferenceDecorator do
 
   describe '#receiver' do
     let(:transference) do
-      create(:transference,
-             receiver_id: receiver.id)
+      create(:transference, receiver_id: receiver.id)
     end
 
     let(:receiver) { create(:account, name: 'Receiver') }

--- a/spec/factories/transference.rb
+++ b/spec/factories/transference.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :transference do
     date { Time.zone.today }
-    value_cents { rand(1.0..100_00.0).round(2) }
+    amount { rand(1.0..100_00.0).round(2) }
     user { create(:user) }
     sender_id { create(:account).id }
     receiver_id { create(:account).id }

--- a/spec/models/transference_spec.rb
+++ b/spec/models/transference_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Transference do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:value_cents) }
+    it { is_expected.to validate_presence_of(:amount) }
 
     it 'validates that sender and receiver are different' do
       account = create(:account)

--- a/spec/services/transference_services/build_transference_spec.rb
+++ b/spec/services/transference_services/build_transference_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TransferenceServices::BuildTransference do
         receiver_id: receiver_account.id,
         sender_id: sender_account.id,
         user_id: user.id,
-        value_cents: '1.23',
+        amount: '1.23',
         date: '2024-03-16'
       }
     end
@@ -26,7 +26,7 @@ RSpec.describe TransferenceServices::BuildTransference do
       expect(response.sender_id).to eq(sender_account.id)
       expect(response.receiver_id).to eq(receiver_account.id)
       expect(response.user_id).to eq(user.id)
-      expect(response.value_cents).to eq(123)
+      expect(response.amount).to eq(1.23)
       expect(response.date).to eq(Date.parse('2024-03-16'))
     end
   end

--- a/spec/services/transference_services/process_transference_request_spec.rb
+++ b/spec/services/transference_services/process_transference_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TransferenceServices::ProcessTransferenceRequest do
     {
       sender_id: sender_account.id,
       receiver_id: receiver_account.id,
-      value_cents: '1.23',
+      amount: '1.23',
       date: '2024-03-17',
       user_id: user.id
     }


### PR DESCRIPTION
closes #99

Refactor transferences to use decimal instead of integer and rename value_cents column.