### PR TITLE
Fix translation typo and add amortized parcels

### DIFF
--- a/app/decorators/financings/financing_decorator.rb
+++ b/app/decorators/financings/financing_decorator.rb
@@ -38,7 +38,7 @@ module Financings
     end
 
     def amortized_parcels
-      object.payments.where(ordinary: false).count
+      object.payments.where(ordinary: false).sum(:paid_parcels)
     end
 
     def monetary_correction

--- a/app/decorators/financings/financing_decorator.rb
+++ b/app/decorators/financings/financing_decorator.rb
@@ -37,6 +37,10 @@ module Financings
       object.payments.where(ordinary: false).count
     end
 
+    def amortized_parcels
+      object.payments.where(ordinary: false).count
+    end
+
     def monetary_correction
       format_currency(object.payments.sum(:monetary_correction))
     end

--- a/app/views/financing/financings/_summary.html.erb
+++ b/app/views/financing/financings/_summary.html.erb
@@ -9,6 +9,7 @@
         <th><%= t('financing.show.summary.parcels') %></th>
         <th><%= t('financing.show.summary.outstanding_amount') %></th>
         <th><%= t('financing.show.summary.outstanding_parcels') %></th>
+        <th><%= t('financing.show.summary.amortized_parcels') %></th>
     </thead>
     <tbody>
       <tr>
@@ -16,6 +17,7 @@
         <td><%= financing.installments %></td>
         <td><%= financing.outstanding_balance %></td>
         <td><%= financing.outstanding_parcels %></td>
+        <td><%= financing.amortized_parcels %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/financing/financings/_summary.html.erb
+++ b/app/views/financing/financings/_summary.html.erb
@@ -6,25 +6,26 @@
   <table class="striped">
     <thead>
         <th><%= t('financing.show.summary.borrowed_amount') %></th>
-        <th><%= t('financing.show.summary.parcels') %></th>
         <th><%= t('financing.show.summary.outstanding_amount') %></th>
-        <th><%= t('financing.show.summary.outstanding_parcels') %></th>
+        <th><%= t('financing.show.summary.parcels') %></th>
+        <th><%= t('financing.show.summary.paid_parcels') %></th>
         <th><%= t('financing.show.summary.amortized_parcels') %></th>
+        <th><%= t('financing.show.summary.outstanding_parcels') %></th>
     </thead>
     <tbody>
       <tr>
         <td><%= financing.borrowed_value %></td>
-        <td><%= financing.installments %></td>
         <td><%= financing.outstanding_balance %></td>
-        <td><%= financing.outstanding_parcels %></td>
+        <td><%= financing.installments %></td>
+        <td><%= financing.ordinary_parcels %></td>
         <td><%= financing.amortized_parcels %></td>
+        <td><%= financing.outstanding_parcels %></td>
       </tr>
     </tbody>
   </table>
 
     <table>
     <thead>
-        <th><%= t('financing.show.summary.paid_parcels') %></th>
         <th><%= t('financing.show.summary.total_interest_paid') %></th>
         <th><%= t('financing.show.summary.total_monetary_correction_paid') %></th>
         <th><%= t('financing.show.summary.non_ordinary_parcels_paid') %></th>
@@ -32,7 +33,6 @@
     </thead>
     <tbody>
       <tr>
-        <td><%= financing.ordinary_parcels %></td>
         <td><%= financing.total_interest_paid %></td>
         <td><%= financing.monetary_correction %></td>
         <td><%= financing.non_ordinary_parcels %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,7 @@ en:
         total_interest_paid: Total interest paid
         total_monetary_correction_paid: Total monetary correction paid
         non_ordinary_parcels_paid: Non ordinary parcels paid
+        amortized_parcels: Amortized parcels
         total_amortized: Total amortized
       payments: Payments
       payments_header:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -160,7 +160,7 @@ pt-BR:
         paid_parcels: Parcelas pagas
         total_interest_paid: Total de juros pagos
         total_monetary_correction_paid: Total pago em correção monetária
-        non_ordinary_parcels_paid: Amortiações pagas
+        non_ordinary_parcels_paid: Amortizações pagas
         total_amortized: Total amortizado
       payments: Pagamentos
       payments_header:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -160,7 +160,8 @@ pt-BR:
         paid_parcels: Parcelas pagas
         total_interest_paid: Total de juros pagos
         total_monetary_correction_paid: Total pago em correção monetária
-        non_ordinary_parcels_paid: Amortizações pagas
+        non_ordinary_parcels_paid: Amortizações realizadas
+        amortized_parcels: Parcelas amortizadas
         total_amortized: Total amortizado
       payments: Pagamentos
       payments_header:


### PR DESCRIPTION
Fixes #164

Fix typo in Portuguese translation and add amortized parcels count in financing summary.

* **Translation Fix**: Correct typo 'Amortiações' to 'Amortizações' in `config/locales/pt-BR.yml`.
* **Decorator Update**: Add `amortized_parcels` method to count the number of amortized parcels in `app/decorators/financings/financing_decorator.rb`.
* **View Update**: Add a new column to display the number of amortized parcels in `app/views/financing/financings/_summary.html.erb` and update the table body to include this count.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/efgalvao/organizer_v2/pull/165?shareId=c13306ab-ece7-4d2f-8802-1386918d615d).