### PR TITLE
Add financing preview component and update account view (#241)

### DIFF
--- a/app/assets/stylesheets/components/_preview.scss
+++ b/app/assets/stylesheets/components/_preview.scss
@@ -46,6 +46,18 @@
   margin-bottom: 1rem;
 }
 
+.lcars-financing-preview-item {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  align-items: center;
+  gap: 2rem;
+  background-color: #111;
+  border: 2px solid #9932CC;
+  border-radius: 20px;
+  padding: 1rem 2rem;
+  margin-bottom: 1rem;
+}
+
 .lcars-card-field {
   color: #FF9900;
   font-weight: bold;

--- a/app/views/account/accounts/show.html.erb
+++ b/app/views/account/accounts/show.html.erb
@@ -37,6 +37,7 @@
 
   <%= turbo_frame_tag "new_investment" %>
   <%= turbo_frame_tag "new_transference" %>
+  <%= turbo_frame_tag "preview" %>
 
   <div class="lcars-content">
     <%= render 'summary', :account => @account %>

--- a/app/views/investments/investments/_preview.html.erb
+++ b/app/views/investments/investments/_preview.html.erb
@@ -1,0 +1,34 @@
+<div class="lcars-financing-preview-item">
+  <div class="lcars-card-field">
+    <%= link_to investment.name, investment_path(investment),
+                data: { turbo_frame: "_top" }  %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.kind %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.bucket %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.invested_amount %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.balance %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.current_price_per_share %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.shares_total %>
+  </div>
+
+  <div class="lcars-card-field">
+    <%= investment.average_price %>
+  </div>
+</div>

--- a/app/views/investments/investments/create.turbo_stream.erb
+++ b/app/views/investments/investments/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update "new_investment", "" %>
-  <%= turbo_stream.prepend "investments" do %>
-    <%= render partial: 'account/accounts/investment', object: @investment, locals: { investment: @investment } %>
-  <% end %>
+<%= turbo_stream.update "preview" do %>
+    <%= render partial: 'investments/investments/preview', locals: { investment: @investment } %>
+<% end %>
 <%= render_turbo_stream_flash_messages %>


### PR DESCRIPTION
closes #239 
* Introduced a new financing preview component to display investment details in a grid layout.
* Updated the account view to include a turbo frame for the new preview component.
* Modified the create action to render the financing preview upon investment creation.