### PR TITLE
Add JSON transaction creation endpoint and service

### DIFF
--- a/app/controllers/account/transactions_controller.rb
+++ b/app/controllers/account/transactions_controller.rb
@@ -34,6 +34,16 @@ module Account
       end
     end
 
+    def create_json
+      transaction = Transactions::CreateFromJson.call(params: json_transaction_params, user: current_user)
+
+      if transaction.persisted?
+        render json: { id: transaction.id, message: 'Transação cadastrada.' }, status: :created
+      else
+        render json: { errors: transaction.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
     def update
       transaction = Transactions::Update.call(@transaction.id, update_params)
       if transaction
@@ -77,6 +87,10 @@ module Account
 
     def update_params
       params.require(:transaction).permit(:id, :title, :category_id, :date, :group, :recurrence)
+    end
+
+    def json_transaction_params
+      params.permit(:date, :title, :category, :amount, :group, :type, :parcels, :recurrence, :account)
     end
 
     def anticipate_params

--- a/app/services/transactions/create_from_json.rb
+++ b/app/services/transactions/create_from_json.rb
@@ -1,0 +1,89 @@
+module Transactions
+  class CreateFromJson < ApplicationService
+    REQUIRED_FIELDS = %i[date title category amount group type parcels recurrence account].freeze
+    ALLOWED_TYPES = [0, 1].freeze
+
+    def initialize(params:, user:)
+      @params = params.to_h.symbolize_keys
+      @user = user
+    end
+
+    def self.call(params:, user:)
+      new(params: params, user: user).call
+    end
+
+    def call
+      validation_error = validate_payload
+      return validation_error if validation_error
+
+      transactions = Transactions::BuildParcels.call(mapped_payload)
+      return error_response('Parcels deve ser maior que 0') if transactions.empty?
+
+      transactions.map do |transaction|
+        Transactions::ProcessRequest.call(
+          params: transaction,
+          value_to_update_balance: value_to_update(transaction)
+        )
+      end.first
+    rescue StandardError => e
+      error_response(e.message)
+    end
+
+    private
+
+    attr_reader :params, :user
+
+    def mapped_payload
+      {
+        date: params[:date],
+        title: params[:title],
+        category: params[:category],
+        amount: params[:amount],
+        group: params[:group],
+        type: params[:type],
+        parcels: params[:parcels],
+        recurrence: params[:recurrence],
+        account: account.name
+      }
+    end
+
+    def value_to_update(transaction)
+      transaction[:type] == 'Account::Expense' ? -transaction[:amount].to_d : transaction[:amount].to_d
+    end
+
+    def validate_payload
+      return error_response("Campos obrigatórios ausentes: #{missing_fields.join(', ')}") if missing_fields.any?
+      return error_response('Formato de data inválido. Use YYYY-MM-DD') unless valid_date?
+      return error_response('Type inválido. Use 0 para despesa ou 1 para receita') unless valid_type?
+      return error_response('Conta não encontrada para o usuário') unless account
+
+      nil
+    end
+
+    def missing_fields
+      REQUIRED_FIELDS.select { |field| params[field].blank? }
+    end
+
+    def valid_date?
+      Date.iso8601(params[:date].to_s)
+      true
+    rescue ArgumentError
+      false
+    end
+
+    def valid_type?
+      ALLOWED_TYPES.include?(params[:type].to_i)
+    end
+
+    def account
+      @account ||= Account::Account.find_by(user_id: user.id, name: params[:account]) ||
+                   Account::Account.find_by('user_id = ? AND LOWER(name) = ?', user.id, params[:account].to_s.strip.downcase)
+    end
+
+    def error_response(message)
+      transaction = Account::Transaction.new
+      transaction.errors.add(:base, message)
+      transaction
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   end
 
   scope module: 'account' do
+    post 'transactions/json', to: 'transactions#create_json', as: 'transactions_json'
+
     resources :accounts do
       member do
         get 'consolidate_report', to: 'accounts#consolidate_report', as: 'consolidate_report'

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -61,4 +61,54 @@ RSpec.describe 'Financings::Transaction' do
       end
     end
   end
+
+  describe 'POST /transactions/json' do
+    let!(:category) { create(:category, user: user, name: 'Mercado') }
+
+    context 'with valid parameters' do
+      let(:params) do
+        {
+          date: '2026-04-14',
+          title: 'Compra API',
+          category: category.name,
+          amount: 99.9,
+          group: 'conforto',
+          type: 0,
+          parcels: 1,
+          recurrence: 'one_time',
+          account: account.name
+        }
+      end
+
+      it 'creates a new transaction and returns created status' do
+        expect do
+          post transactions_json_path, params: params, as: :json
+        end.to change(Account::Expense, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:params) do
+        {
+          date: '2026/04/14',
+          title: 'Compra API',
+          category: category.name,
+          amount: 99.9,
+          group: 'conforto',
+          type: 0,
+          parcels: 1,
+          recurrence: 'one_time',
+          account: account.name
+        }
+      end
+
+      it 'returns unprocessable entity' do
+        post transactions_json_path, params: params, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
 end

--- a/spec/services/transactions/create_from_json_spec.rb
+++ b/spec/services/transactions/create_from_json_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Transactions::CreateFromJson do
+  subject(:create_from_json) { described_class.call(params: params, user: user) }
+
+  let(:user) { create(:user) }
+  let!(:account) { create(:account, user: user, name: 'Nubank', balance: 100.0) }
+  let!(:category) { create(:category, user: user, name: 'Mercado') }
+  let(:params) do
+    {
+      date: '2026-04-14',
+      title: 'Compra do mês',
+      category: category.name,
+      amount: 50.0,
+      group: 'conforto',
+      type: 0,
+      parcels: 1,
+      recurrence: 'one_time',
+      account: account.name
+    }
+  end
+
+  it 'creates an expense transaction and updates balance' do
+    expect { create_from_json }.to change(Account::Expense, :count).by(1)
+
+    account.reload
+    created_transaction = Account::Expense.order(:id).last
+
+    expect(created_transaction.title).to eq('Compra do mês')
+    expect(account.balance).to eq(50.0)
+  end
+
+  context 'when transaction is an income' do
+    let(:params) { super().merge(type: 1, amount: 25.5, title: 'Recebimento') }
+
+    it 'creates income and increases account balance' do
+      expect { create_from_json }.to change(Account::Income, :count).by(1)
+
+      account.reload
+      expect(account.balance).to eq(125.5)
+    end
+  end
+
+  context 'when account does not exist for user' do
+    let(:params) { super().merge(account: 'Conta inexistente') }
+
+    it 'returns an invalid transaction with errors' do
+      response = create_from_json
+
+      expect(response).to be_a(Account::Transaction)
+      expect(response).not_to be_persisted
+      expect(response.errors.full_messages).to include('Conta não encontrada para o usuário')
+    end
+  end
+
+  context 'when date is invalid' do
+    let(:params) { super().merge(date: '14-04-2026') }
+
+    it 'returns an invalid transaction with errors' do
+      response = create_from_json
+
+      expect(response).to be_a(Account::Transaction)
+      expect(response).not_to be_persisted
+      expect(response.errors.full_messages).to include('Formato de data inválido. Use YYYY-MM-DD')
+    end
+  end
+end


### PR DESCRIPTION
closes #267 
- Introduced a new endpoint for creating transactions via JSON in the transactions controller.
- Implemented the Transactions::CreateFromJson service to handle transaction creation logic, including validation and processing.
- Added tests for the new endpoint and service to ensure correct functionality with both valid and invalid parameters.
- Updated routes to include the new JSON transaction creation path.